### PR TITLE
Update schemas.py

### DIFF
--- a/steampassword/schemas.py
+++ b/steampassword/schemas.py
@@ -13,7 +13,7 @@ class RSAKey(pydantic.BaseModel):
     mod: str
     exp: str
     timestamp: int
-    token_gid: str
+    token_gid: str = None
 
     class Config:
         fields = {

--- a/steampassword/schemas.py
+++ b/steampassword/schemas.py
@@ -13,7 +13,7 @@ class RSAKey(pydantic.BaseModel):
     mod: str
     exp: str
     timestamp: int
-    token_gid: str = None
+    token_gid: Optional[str] = None
 
     class Config:
         fields = {


### PR DESCRIPTION
n the example code shown, it fails with the error pydantic.error_wrappers.ValidationError: 1 validation error for RSAKey token_gid
  field required (type=value_error.missing)
If you set the field to be optional, everything starts to work